### PR TITLE
Adds better logging of mismatched atoms

### DIFF
--- a/Code/GraphMol/StructChecker/Pattern.cpp
+++ b/Code/GraphMol/StructChecker/Pattern.cpp
@@ -335,9 +335,11 @@ bool CheckAtoms(const ROMol &mol, const std::vector<AugmentedAtom> &good_atoms, 
 //      }
 //   }
 
+    
     for (unsigned i = 0; i < mol.getNumAtoms(); i++) {
         unsigned prevn = nmatch;
-        for (unsigned j = 0; j < good_atoms.size(); j++)
+        unsigned int j = 0;
+        for (; j < good_atoms.size(); j++)
         {
             // check for ring state of central atom. Ring matches to ring only
             if (good_atoms[j].Topology == RING && 0 == atom_status[i]) {
@@ -357,6 +359,12 @@ bool CheckAtoms(const ROMol &mol, const std::vector<AugmentedAtom> &good_atoms, 
             BOOST_LOG(rdInfoLog) << "UNMATCHED atom idx=" << i << " "
             << mol.getAtomWithIdx(i)->getSymbol() << " status=" << atom_status[i]
             << " nmatch=" << nmatch << "\n";
+
+        if ( verbose && j == good_atoms.size() ) { // failed this atom .. log it
+          BOOST_LOG(rdWarningLog) << LogNeighbourhood(mol, i, neighbours)
+                                  << std::endl;
+        }
+        
     }
     return (nmatch == mol.getNumAtoms());
 }

--- a/Code/GraphMol/StructChecker/Utilites.h
+++ b/Code/GraphMol/StructChecker/Utilites.h
@@ -22,6 +22,9 @@ namespace RDKit {
         void SetupNeighbourhood(const ROMol &mol, std::vector<Neighbourhood> &neighbour_array);
         bool getMolAtomPoints(const ROMol& mol, std::vector<RDGeom::Point3D> &atomPoint);
 
+        std::string LogNeighbourhood(const ROMol &mol,
+                                     unsigned int idx,
+                                     const std::vector<Neighbourhood> &bneighbour_array);
     }
 }
 


### PR DESCRIPTION
We still seem to have an issue with some simple atom environments:

```
[15:14:18] squiggle bond from double bond    atom 0   AA : C(-C)(=C)
[15:14:18] squiggle bond from double bond    atom 1   AA : C(-C)(=C)
[15:14:18] squiggle bond from double bond    atom 2   AA : C(-C)
[15:14:18] squiggle bond from double bond    atom 3   AA : C(-C)
```

This is from the molb that greg was using before

```
molb = '''squiggle bond from chiral center
  Mrv1561 08171605252D          

  5  4  0  0  0  0            999 V2000
   -1.7411    2.3214    0.0000 F   0  0  0  0  0  0  0  0  0  0  0  0
   -0.9161    2.3214    0.0000 C   0  0  3  0  0  0  0  0  0  0  0  0
   -0.0911    2.3214    0.0000 Br  0  0  0  0  0  0  0  0  0  0  0  0
   -0.9161    3.1464    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
   -0.9161    1.4964    0.0000 Cl  0  0  0  0  0  0  0  0  0  0  0  0
  1  2  1  0  0  0  0
  2  3  1  0  0  0  0
  2  5  1  0  0  0  0
  2  4  1  4  0  0  0
M  END
'''
```

This PR adds the Log neighborhood functionality in struchk so we can log the missing atom environments and compare them to struchk

I've added the tests to the test suite at https://github.com/bp-kelley/struchk-testing.git in check-stereo-struchk.py 
