### PR TITLE
Removes the same fragments that strucheck does in case of ties

### DIFF
--- a/Code/GraphMol/StructChecker/StripSmallFragments.cpp
+++ b/Code/GraphMol/StructChecker/StripSmallFragments.cpp
@@ -43,10 +43,11 @@ void AddMWMF(RWMol &mol,
 bool StripSmallFragments(RWMol &mol, bool verbose) {
   const bool sanitize=false;
   std::vector<boost::shared_ptr<ROMol> > frags = MolOps::getMolFrags(mol, sanitize);
+  if (frags.size() <= 1)
+    return false;
+
   size_t maxFragSize = 0;
   size_t maxFragIdx = 0;
-  if (frags.size() == 1)
-    return false;
   
   for(size_t i=0; i<frags.size(); ++i) {
     const unsigned int fragSize = frags[i].get()->getNumAtoms();

--- a/Code/GraphMol/StructChecker/StripSmallFragments.cpp
+++ b/Code/GraphMol/StructChecker/StripSmallFragments.cpp
@@ -41,7 +41,7 @@ void AddMWMF(RWMol &mol,
 }
 
 bool StripSmallFragments(RWMol &mol, bool verbose) {
-  const bool sanitize=true;
+  const bool sanitize=false;
   std::vector<boost::shared_ptr<ROMol> > frags = MolOps::getMolFrags(mol, sanitize);
   size_t maxFragSize = 0;
   size_t maxFragIdx = 0;

--- a/Code/GraphMol/StructChecker/StripSmallFragments.h
+++ b/Code/GraphMol/StructChecker/StripSmallFragments.h
@@ -12,7 +12,7 @@
 
 namespace RDKit {
 namespace StructureCheck {
-bool StripSmallFragments(RWMol &mol);
+bool StripSmallFragments(RWMol &mol, bool verbose=false);
 void AddMWMF(
     RWMol &mol,
     bool pre);  // set mol formula & mass properties "MW_PRE" or "MW_POST"

--- a/Code/GraphMol/StructChecker/StructChecker.cpp
+++ b/Code/GraphMol/StructChecker/StructChecker.cpp
@@ -51,7 +51,7 @@ unsigned StructChecker::checkMolStructure(RWMol &mol) const {
 
   if (Options.RemoveMinorFragments) {
     AddMWMF(mol, true);  // Add mol mass data field "MW_PRE"
-    if (StripSmallFragments(mol)) {
+    if (StripSmallFragments(mol, Options.Verbose)) {
       flags |= FRAGMENTS_FOUND;
     }
     AddMWMF(mol, false);  // Add mol mass data field "MW_POST"

--- a/Code/GraphMol/StructChecker/StructChecker.cpp
+++ b/Code/GraphMol/StructChecker/StructChecker.cpp
@@ -24,6 +24,11 @@ unsigned StructChecker::checkMolStructure(RWMol &mol) const {
                                   mol.getNumBonds() > Options.MaxMolSize)) {
     return SIZE_CHECK_FAILED;
   }
+
+  if (mol.getNumAtoms() == 0) {
+    return SIZE_CHECK_FAILED;
+  }
+  
   if (!mol.getRingInfo()->isInitialized()) mol.getRingInfo()->initialize();
 
   /* it uses SDL text

--- a/Code/GraphMol/StructChecker/StructChecker.cpp
+++ b/Code/GraphMol/StructChecker/StructChecker.cpp
@@ -110,7 +110,7 @@ unsigned StructChecker::checkMolStructure(RWMol &mol) const {
     if (ch.rechargeMolecule(ndeprot, nrefine)) flags |= RECHARGED;
   }
   //
-  double clashLimit = 0.15;  // see void SetCollisionLimit(int percent)
+  const double clashLimit = Options.CollisionLimitPercent/100.0;
   if (Options.CheckCollisions && AtomClash(mol, clashLimit))
     flags |= ATOM_CLASH;
 

--- a/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
+++ b/Code/GraphMol/StructChecker/StructCheckerOptions.cpp
@@ -663,7 +663,7 @@ StructCheckerOptions::StructCheckerOptions()
       RemoveMinorFragments(false),
       DesiredCharge(0),
       CheckCollisions(false),
-      CollisionLimitPercent(0),
+      CollisionLimitPercent(15),
       MaxMolSize(255),
       ConvertSText(false),
       SqueezeIdentifiers(false),

--- a/Code/GraphMol/StructChecker/Utilites.cpp
+++ b/Code/GraphMol/StructChecker/Utilites.cpp
@@ -33,7 +33,8 @@ void SetupNeighbourhood(const ROMol &mol,
 }
 
 bool getMolAtomPoints(const ROMol &mol,
-                      std::vector<RDGeom::Point3D> &atomPoint) {
+                      std::vector<RDGeom::Point3D> &atomPoint,
+                      bool twod) {
   bool non_zero_z = false;
   atomPoint.resize(mol.getNumAtoms());
   // take X,Y,Z coordinates of each atom
@@ -41,7 +42,7 @@ bool getMolAtomPoints(const ROMol &mol,
     for (RDKit::ROMol::ConstConformerIterator cnfi = mol.beginConformers();
          cnfi != mol.endConformers(); cnfi++) {
       const Conformer &conf = **cnfi;  // mol.getConformer(confId);
-      if (conf.is3D()) {
+      if (twod || conf.is3D()) {
         for (unsigned i = 0; i < mol.getNumAtoms(); i++) {
           atomPoint[i] = conf.getAtomPos(i);
           if (fabs(atomPoint[i].z) >= 1.e-7) non_zero_z = true;

--- a/Code/GraphMol/StructChecker/Utilites.h
+++ b/Code/GraphMol/StructChecker/Utilites.h
@@ -22,7 +22,7 @@ struct Neighbourhood {          // a set of an atom neighbours
 void SetupNeighbourhood(const ROMol &mol,
                         std::vector<Neighbourhood> &neighbour_array);
 bool getMolAtomPoints(const ROMol &mol,
-                      std::vector<RDGeom::Point3D> &atomPoint);
+                      std::vector<RDGeom::Point3D> &atomPoint, bool twod=false);
 
 std::string LogNeighbourhood(
     const ROMol &mol, unsigned int idx,

--- a/Code/GraphMol/StructChecker/Wrap/structchecker.cpp
+++ b/Code/GraphMol/StructChecker/Wrap/structchecker.cpp
@@ -94,6 +94,9 @@ struct struct_wrapper {
         .def_readwrite(
             "CheckCollisions",
             &RDKit::StructureCheck::StructCheckerOptions::CheckCollisions)
+        .def_readwrite(
+            "CollisionLimitPercent",
+            &RDKit::StructureCheck::StructCheckerOptions::CollisionLimitPercent)
         .def_readwrite("MaxMolSize",
                        &RDKit::StructureCheck::StructCheckerOptions::MaxMolSize)
         .def_readwrite(


### PR DESCRIPTION
Simple "fix" to make this implementation choose the same fragment as struchk in case of ties in fragment size.  I think we should probably fail here with a "Can't choose fragment" error, but this fixes a bunch of regression tests with the pubchem data.

Also simplifies the fragmentation using rdkit internal code.
